### PR TITLE
refs qorelanguage/qore#4289 fixed additional namespace clashes and na…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(qore-python-module)
 
 set (VERSION_MAJOR 1)
 set (VERSION_MINOR 0)
-set (VERSION_PATCH 2)
+set (VERSION_PATCH 3)
 
 set(PROJECT_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -500,6 +500,13 @@ PythonProgram::setSaveObjectCallback(callback);
 
     @section pythonreleasenotes python Module Release Notes
 
+    @subsection python_1_0_3 python Module Version 1.0.3
+    - do not shut down the %Python library on exit, as it will cause a crash in exit handlers in %Python modules that
+      require the library to be in place (ex: h5py module v 3.3.0)
+      (<a href="https://github.com/qorelanguage/qore/issues/4290">issue 4290</a>)
+    - fixed additional namespace clashes and namespace allocation issues for imported %Python classes in %Qore
+      (<a href="https://github.com/qorelanguage/qore/issues/4289">issue 4289</a>)
+
     @subsection python_1_0_2 python Module Version 1.0.2
     - fixed issues handling the case when the python module is initialized with no Program context
       (<a href="https://github.com/qorelanguage/qore/issues/4153">issue 4153</a>)

--- a/src/QorePythonProgram.h
+++ b/src/QorePythonProgram.h
@@ -63,6 +63,8 @@ struct QorePythonThreadStateInfo {
 class QorePythonProgram : public AbstractQoreProgramExternalData {
     friend class PythonModuleContextHelper;
 public:
+    typedef std::set<std::string> strset_t;
+
     //! Python context using the main interpreter
     DLLLOCAL QorePythonProgram();
 
@@ -289,7 +291,7 @@ public:
 
     //! Populates the QoreClass based on the Python class
     DLLLOCAL QorePythonClass* setupQorePythonClass(ExceptionSink* xsink, QoreNamespace* ns, PyTypeObject* type,
-            std::unique_ptr<QorePythonClass>& cls, int flags = 0);
+            std::unique_ptr<QorePythonClass>& cls, strset_t& nsset, int flags = 0);
 
     //! Creates ot retrieves a QoreClass for the given Python type
     DLLLOCAL QoreClass* getCreateQorePythonClass(ExceptionSink* xsink, PyTypeObject* type, int flags = 0);
@@ -429,7 +431,6 @@ protected:
     pyobj_set_t mod_set;
 
     //! set of unique strings
-    typedef std::set<std::string> strset_t;
     strset_t strset;
 
     //! mutex for thread state map
@@ -474,11 +475,11 @@ protected:
 
     DLLLOCAL QoreNamespace* getNamespaceForObject(PyObject* type);
 
-    DLLLOCAL QoreClass* getCreateQorePythonClassIntern(ExceptionSink* xsink, PyTypeObject* type,
+    DLLLOCAL QoreClass* getCreateQorePythonClassIntern(ExceptionSink* xsink, PyTypeObject* type, strset_t& nsset,
         const char* cls_name = nullptr, int flags = 0);
 
     DLLLOCAL QorePythonClass* addClassToNamespaceIntern(ExceptionSink* xsink, QoreNamespace* ns, PyTypeObject* type,
-        const char* cname, clmap_t::iterator i, int flags = 0);
+        const char* cname, clmap_t::iterator i, strset_t& nsset, int flags = 0);
 
     //! Call a method and and return the result
     DLLLOCAL QoreValue callCFunctionMethod(ExceptionSink* xsink, PyObject* func, const QoreListNode* args,

--- a/src/python-module.cpp
+++ b/src/python-module.cpp
@@ -233,7 +233,12 @@ static QoreStringNode* python_module_init_intern(bool repeat) {
         }
 
         Py_InitializeEx(0);
+#ifndef QORE_ALLOW_PYTHON_SHUTDOWN
+        // issue# 4290: if we actively shut down Python on exit, then exit handlers in modules
+        // (such as the h5py module in version 3.3.0) will cause a crash when the process exits,
+        // as it requires the Python library to be still in place and initialized
         python_needs_shutdown = true;
+#endif
         //printd(5, "python_module_init() Python initialized\n");
     }
 


### PR DESCRIPTION
…mespace allocation issues for imported Python classes in Qore

refs qorelanguage/qore#4290 do not shut down the Python library on exit, as it will cause a crash in exit handlers in Python modules that require the library to be in place (ex: h5py module v3.3.0)