### PR TITLE
refs qorelanguage/qore#4373 added code to store the Python module nam…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(qore-python-module)
 
 set (VERSION_MAJOR 1)
 set (VERSION_MINOR 1)
-set (VERSION_PATCH 0)
+set (VERSION_PATCH 1)
 
 set(PROJECT_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -500,6 +500,11 @@ PythonProgram::setSaveObjectCallback(callback);
 
     @section pythonreleasenotes python Module Release Notes
 
+    @subsection python_1_1_1 python Module Version 1.1.1
+    - mark %Qore namespaces imported from %Python modules so that other languages like Java can use consistent paths
+      with %Python symbols
+      (<a href="https://github.com/qorelanguage/qore/issues/4373">issue 4373</a>)
+
     @subsection python_1_1 python Module Version 1.1
     - added support for Python 3.10
       (<a href="https://github.com/qorelanguage/qore/issues/4334">issue 4334</a>)

--- a/qore-python-module.spec
+++ b/qore-python-module.spec
@@ -5,7 +5,7 @@
 %global user_module_dir %{mydatarootdir}/qore-modules/
 
 Name:           qore-python-module
-Version:        1.1.0
+Version:        1.1.1
 Release:        1
 Summary:        Qorus Integration Engine - Qore Python module
 License:        MIT
@@ -55,6 +55,9 @@ make DESTDIR=%{buildroot} install %{?_smp_mflags}
 %{module_dir}
 
 %changelog
+* Fri Oct 31 2021 David Nichols <david@qore.org>
+- updated to version 1.1.1
+
 * Wed Oct 27 2021 David Nichols <david@qore.org>
 - updated to version 1.1.0
 

--- a/src/QorePythonProgram.cpp
+++ b/src/QorePythonProgram.cpp
@@ -2120,7 +2120,15 @@ QoreNamespace* QorePythonProgram::getNamespaceForObject(PyObject* obj) {
 
     //printd(5, "QorePythonProgram::getNamespaceForObject() obj %p (%s) -> ns: Python::%s\n", obj,
     //  Py_TYPE(obj)->tp_name, ns_path.c_str());
-    return pyns->findCreateNamespacePathAll(ns_path.c_str());
+    QoreNamespace* ns = pyns->findCreateNamespacePathAll(ns_path.c_str());
+#if QORE_VERSION_CODE >= 10013
+    if (module_context) {
+        if (ns->setKeyValueIfNotSet("python_module", module_context)) {
+            printd(5, "set python_module: '%s' in ns: '%s'\n", module_context, ns->getPath(true).c_str());
+        }
+    }
+#endif
+    return ns;
 }
 
 QoreClass* QorePythonProgram::getCreateQorePythonClassIntern(ExceptionSink* xsink, PyTypeObject* type,


### PR DESCRIPTION
…e in all namespaces created while importing python modules; allowing for consistent binary paths in the Java module for imported code and also allowing for required Python modules to be implicitly imported from Java as well based on the binary name